### PR TITLE
Set setup long desc type to MD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ def run_setup():
         version='0.3',
         description='Python wrapper around the xcrun utility',
         long_description=long_description,
+        long_description_content_type='text/markdown',
         url='https://github.com/dalemyers/xcrun',
         author='Dale Myers',
         author_email='dale@myers.io',


### PR DESCRIPTION
The long description on PyPi is currently not set to markdown. This should fix it at the next release.