### PR TITLE
Mojave & 10.1 Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 **/.cache/**
 htmlcov/**
 .pytest_cache
+.tox
+.mypy_cache/**
+**/__pycache__
+venv
+*.egg-info
+.coverage
+*.pyc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,17 @@
     "editor.useTabStops": false,
     "editor.tabSize": 4,
     "search.exclude": {
+        "venv/**": true,
         "**/.git": true,
         "**/.tox": true,
         "**/.dist": true,
         "**/.cache": true,
         "**/xcrun.egg-info": true
-    }
+    },
+    "python.unitTest.pyTestArgs": [
+        "tests"
+    ],
+    "python.unitTest.unittestEnabled": false,
+    "python.unitTest.nosetestsEnabled": false,
+    "python.unitTest.pyTestEnabled": true
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xcrun
 
-This is a Python wrapper around the `xcrun` utility that Apple provides for interacting with the various Xcode developer tools. 
+This is a Python wrapper around the `xcrun` utility that Apple provides for interacting with the various Xcode developer tools. This module has been tested against python 2.7, 3.6 & 3.7.
 
 ## simctl
 
@@ -23,4 +23,7 @@ You can do this:
 
 ## Testing
 
-To run the tests, all you need to do is run `python3 -m tox` (can be installed by running `python3 -m pip install tox`). 
+* `python3 -m tox` to run the tests. Tox can be installed by running `python3 -m pip install tox`.
+  * If using pyenv you need to make sure you have 2.7, 3.6, 3.7 activated with `pyenv local 2.7, 3.6, 3.7 && pyenv rehash`. See this [pyenv/pyenv92](https://github.com/pyenv/pyenv/issues/92) for more details.
+* `python3 -m pytest -m slow` to run the slow tests.
+

--- a/tests/test_device_types.py
+++ b/tests/test_device_types.py
@@ -101,5 +101,5 @@ class TestDeviceTypes(unittest.TestCase):
     def test_string_representations(self):
         """Test that the string representations are unique."""
         all_device_types = xcrun.simctl.listall.device_types()
-        strings = set([str(device_type) for device_type in all_device_types])
+        strings = set([device_type.__str__() for device_type in all_device_types])
         self.assertEqual(len(strings), len(all_device_types))

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import pytest
 import subprocess
 import unittest
 import uuid
@@ -18,6 +19,7 @@ class TestDevice(unittest.TestCase):
         TestDevice.available_runtimes = xcrun.simctl.listall.runtimes()
         TestDevice.available_device_types = xcrun.simctl.listall.device_types()
 
+    @pytest.mark.slow
     def test_lifecycle(self):
         """Test that we can create new devices in a consistent manner."""
 
@@ -51,7 +53,7 @@ class TestDevice(unittest.TestCase):
                 try:
                     device = xcrun.simctl.device.create(device_name, available_device_type, available_runtime)
                 except subprocess.CalledProcessError as ex:
-                    if ex.returncode == 162:
+                    if ex.returncode == 162 or ex.returncode == 22:
                         # This was an incompatible pairing. That's fine since 
                         # we could be matching watchOS with an iOS device, or
                         # an iOS version with an older device, etc.

--- a/tests/test_runtimes.py
+++ b/tests/test_runtimes.py
@@ -40,7 +40,7 @@ class TestRuntime(unittest.TestCase):
         command = "xcrun simctl list runtimes | tail -n +2 | sed 's/.* - //'"
         runtimes = subprocess.check_output(command, universal_newlines=True, shell=True)
         runtimes = runtimes.split("\n")
-        runtimes = [runtime for runtime in runtimes if len(runtime) > 0]
+        runtimes = [runtime.strip() for runtime in runtimes if len(runtime) > 0 if "unavailable" not in runtime]
         self.assertTrue(len(runtimes) > 0)
 
         runtime_identifier = random.choice(runtimes)
@@ -55,7 +55,7 @@ class TestRuntime(unittest.TestCase):
         command = "xcrun simctl list runtimes | tail -n +2 | sed -e 's/ (.*//'"
         runtimes = subprocess.check_output(command, universal_newlines=True, shell=True)
         runtimes = runtimes.split("\n")
-        runtimes = [runtime for runtime in runtimes if len(runtime) > 0]
+        runtimes = [runtime.strip() for runtime in runtimes if len(runtime) > 0 if "unavailable" not in runtime]
         self.assertTrue(len(runtimes) > 0)
 
         runtime_name = random.choice(runtimes)
@@ -74,7 +74,7 @@ class TestRuntime(unittest.TestCase):
         """Test that we don't accidentially match on invalid names."""
         # It's unlikely that anyone would get the exact same UUID as we generate
         with self.assertRaises(xcrun.simctl.runtime.RuntimeNotFoundError):
-            _ = xcrun.simctl.runtime.from_name(str(uuid.uuid4()))
+            _ = xcrun.simctl.runtime.from_name(uuid.uuid4().__str__())
 
     def test_equality(self):
         """Test that the equality check on runtimes is accurate."""
@@ -102,5 +102,5 @@ class TestRuntime(unittest.TestCase):
     def test_string_representations(self):
         """Test that the string representations are unique."""
         all_runtimes = xcrun.simctl.listall.runtimes()
-        strings = set([str(runtime) for runtime in all_runtimes])
+        strings = set([runtime.__str__() for runtime in all_runtimes])
         self.assertEqual(len(strings), len(all_runtimes))

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,20 @@
 [tox]
-envlist = clean,py37,stats
+envlist = py27,py36,py37
 
 [testenv]
 deps=
   pytest 
   coverage
-commands=coverage run --include=xcrun/** /usr/local/bin/pytest
-
-[testenv:clean]
 commands=
-  coverage erase
+  {envbindir}/coverage erase
+  {envbindir}/pytest -m "not slow" {posargs}
 
-[testenv:stats]
+[testenv:py36]
+deps=
+  pytest
+  coverage
 commands=
-  coverage report
-  coverage html
+  {envbindir}/coverage erase
+  {envbindir}/coverage run --source xcrun {envbindir}/pytest -m "not slow" {posargs}
+  {envbindir}/coverage report
+  {envbindir}/coverage html

--- a/xcrun/simctl/device_type.py
+++ b/xcrun/simctl/device_type.py
@@ -33,6 +33,9 @@ class DeviceType(object):
         """Return a user readable string representing the device type."""
         return self.name + ": " + self.identifier
 
+    def __repr__(self):
+        return self.__str__()
+
 
 def from_xcrun_info(info):
     """Create a new device type from the xcrun info."""

--- a/xcrun/simctl/device_type.py
+++ b/xcrun/simctl/device_type.py
@@ -34,7 +34,8 @@ class DeviceType(object):
         return self.name + ": " + self.identifier
 
     def __repr__(self):
-        return self.__str__()
+        """Return the raw info of the simctl output"""
+        return self.raw_info.__str__()
 
 
 def from_xcrun_info(info):

--- a/xcrun/simctl/runtime.py
+++ b/xcrun/simctl/runtime.py
@@ -36,7 +36,12 @@ class Runtime(object):
 
     def __str__(self):
         """Return a string representation of the runtime."""
-        return "%s: %s" % (self.name, self.identifier)
+        return "%s:  %s" % (self.name, self.identifier)
+
+    def __repr__(self):
+        """Return a string representation of the runtime."""
+        return self.raw_info.__repr__()
+
 
 
 def from_xcrun_info(info):

--- a/xcrun/simctl/runtime.py
+++ b/xcrun/simctl/runtime.py
@@ -39,7 +39,7 @@ class Runtime(object):
         return "%s:  %s" % (self.name, self.identifier)
 
     def __repr__(self):
-        """Return a string representation of the runtime."""
+        """Return the raw info of the simctl output"""
         return self.raw_info.__repr__()
 
 


### PR DESCRIPTION
Hi, this is a great simctl wrapper that I'm looking to use in a few scripts. Thanks for sharing it 👍.

I found the unit tests were failing on Mojave 10.14 with Xcode 10.1. This PR:

* Updates the tests to pass on 10.14 with Xcode 10.1 & 9.4.1
* Updates the tox configuration to:
  * Run against python 2.7, 3.6 & 3.7
  * Only generate coverage on 3.6
  * Use the pytest from the top virtualenv
  * Only runs the fast tests by default. test_devices.py takes 100 seconds to run on my machine so testing against all 3 environments is a full 5 minutes. 
* Update the gitignore & vscode settings
* Add `__repr__` implementations to a few classes that I was testing out in the repl.