### PR TITLE
Xcode 11 doesn't return the `availability` property any more

### DIFF
--- a/isim/device.py
+++ b/isim/device.py
@@ -27,7 +27,7 @@ class Device(SimulatorControlBase):
     raw_info: Dict[str, Any]
 
     availability_error: str
-    availability: str
+    availability: Optional[str]
     is_available: str
     name: str
     runtime_id: str
@@ -46,7 +46,7 @@ class Device(SimulatorControlBase):
         super().__init__(device_info, SimulatorControlType.device)
         self._runtime = None
         self.raw_info = device_info
-        self.availability = device_info["availability"]
+        self.availability = device_info.get("availability", None)
         self.availability_error = device_info["availabilityError"]
         self.is_available = device_info["isAvailable"]
         self.name = device_info["name"]

--- a/isim/runtime.py
+++ b/isim/runtime.py
@@ -1,6 +1,6 @@
 """Handles the runtimes for simctl."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from isim.base_types import SimulatorControlBase, SimulatorControlType
 
@@ -12,7 +12,7 @@ class Runtime(SimulatorControlBase):
     """Represents a runtime for the iOS simulator."""
 
     raw_info: Dict[str, Any]
-    availability: str
+    availability: Optional[str]
     availability_error: str
     build_version: str
     bundle_path: str
@@ -29,7 +29,7 @@ class Runtime(SimulatorControlBase):
 
         super().__init__(runtime_info, SimulatorControlType.runtime)
         self.raw_info = runtime_info
-        self.availability = runtime_info["availability"]
+        self.availability = runtime_info.get("availability", None)
         self.availability_error = runtime_info["availabilityError"]
         self.build_version = runtime_info["buildversion"]
         self.bundle_path = runtime_info["bundlePath"].replace("\\/", "/")


### PR DESCRIPTION
Xcode 11 removed the field `availability` from its output, which causes isim to raise an exception:

```
Traceback (most recent call last):
  File "/Users/obitow/Developer/icash_appium_native/common/device/api.py", line 128, in start_device
    device.up()
  File "/Users/obitow/Developer/icash_appium_native/common/device/device.py", line 159, in up
    _simulator = SimulatorControl.from_name(self.name)
  File "/Users/obitow/Developer/icash_appium_native/venv/lib/python3.7/site-packages/isim/device.py", line 243, in from_name
    for runtime_name, runtime_devices in Device.list_all().items():
  File "/Users/obitow/Developer/icash_appium_native/venv/lib/python3.7/site-packages/isim/device.py", line 298, in list_all
    return Device.from_simctl_info(raw_info)
  File "/Users/obitow/Developer/icash_appium_native/venv/lib/python3.7/site-packages/isim/device.py", line 215, in from_simctl_info
    devices.append(Device(device_info, runtime_name))
  File "/Users/obitow/Developer/icash_appium_native/venv/lib/python3.7/site-packages/isim/device.py", line 43, in __init__
    self.availability = device_info["availability"]
KeyError: 'availability'
```
From the [release notes](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_beta_release_notes):
> The previously deprecated availability field in simctl list’s JSON output is removed. Use the isAvailable Boolean field to determine availability. (45142676)